### PR TITLE
feat: add myos dev v0.7 with bootstrap doc type and unified account id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 blue-preprocessed
+CLAUDE.md

--- a/MyOSDevV0.7/DocumentSessionBootstrap.blue
+++ b/MyOSDevV0.7/DocumentSessionBootstrap.blue
@@ -1,14 +1,11 @@
 name: Document Session Bootstrap
 description: MyOS-specific document for bootstrapping document sessions and tracking bootstrap progress
-status:
-  type: Text
-  description: Current status (ResolvingParticipants, Completed, Failed)
 document:
   description: Target Blue document to be bootstrapped
 channelBindings:
   type: Dictionary
   keyType: Text
-  valueType: MyOS Timeline Channel
+  valueType: Channel
   description: Maps channel names to participant identifiers
 initialMessages:
   description: Messages sent to participants when inviting them to the bootstrapped document
@@ -27,9 +24,22 @@ capabilities:
   description: Optional MyOS Admin capability contracts to attach (participantsOrchestration, sessionInteraction, workerAgency)
 contracts:
   description: Operational contracts for the bootstrap session participants
-  initiatorChannel:
-    type: MyOS Timeline Channel
-    description: Timeline channel for the user who initiated the bootstrap process
   myOsAdminChannel:
     type: MyOS Timeline Channel
     description: Timeline channel for MyOS Admin to orchestrate the bootstrap process and emit progress events
+  myOsAdminUpdate:
+    type: Operation
+    description: Operation for MyOS Admin to emit progress events during bootstrap process
+    channel: myOsAdminChannel
+    request:
+      type: List
+      description: List of events to emit
+  myOsAdminUpdateImpl:
+    type: Sequential Workflow Operation
+    description: Implementation that re-emits the provided events
+    operation: myOsAdminUpdate
+    steps:
+      - name: EmitAdminEvents
+        type: JavaScript Code
+        code: |
+          return { events: event };

--- a/MyOSDevV0.7/DocumentSessionBootstrap.blue
+++ b/MyOSDevV0.7/DocumentSessionBootstrap.blue
@@ -1,0 +1,35 @@
+name: Document Session Bootstrap
+description: MyOS-specific document for bootstrapping document sessions and tracking bootstrap progress
+status:
+  type: Text
+  description: Current status (ResolvingParticipants, Completed, Failed)
+document:
+  description: Target Blue document to be bootstrapped
+channelBindings:
+  type: Dictionary
+  keyType: Text
+  valueType: MyOS Timeline Channel
+  description: Maps channel names to participant identifiers
+initialMessages:
+  description: Messages sent to participants when inviting them to the bootstrapped document
+  defaultMessage:
+    type: Text
+    description: Default invitation message sent to all participants
+  perChannel:
+    type: Dictionary
+    keyType: Text
+    valueType: Text
+    description: Per-channel custom invitation messages
+capabilities:
+  type: Dictionary
+  keyType: Text
+  valueType: Boolean
+  description: Optional MyOS Admin capability contracts to attach (participantsOrchestration, sessionInteraction, workerAgency)
+contracts:
+  description: Operational contracts for the bootstrap session participants
+  initiatorChannel:
+    type: MyOS Timeline Channel
+    description: Timeline channel for the user who initiated the bootstrap process
+  myOsAdminChannel:
+    type: MyOS Timeline Channel
+    description: Timeline channel for MyOS Admin to orchestrate the bootstrap process and emit progress events

--- a/MyOSDevV0.7/MyOSAgent.blue
+++ b/MyOSDevV0.7/MyOSAgent.blue
@@ -1,0 +1,5 @@
+name: MyOS Agent
+description: MyOS-specific agent with optional agent identifier
+agentId:
+  type: Text
+  description: Optional agent identifier

--- a/MyOSDevV0.7/MyOSAgentChannel.blue
+++ b/MyOSDevV0.7/MyOSAgentChannel.blue
@@ -1,0 +1,7 @@
+name: MyOS Agent Channel
+description: MyOS-specific agent channel extending Channel with agent and event fields
+agent:
+  type: MyOS Agent
+  description: Optional MyOS agent associated with this channel
+event:
+  description: Optional event node reference

--- a/MyOSDevV0.7/MyOSAgentEvent.blue
+++ b/MyOSDevV0.7/MyOSAgentEvent.blue
@@ -1,0 +1,13 @@
+name: MyOS Agent Event
+description: MyOS-specific agent event with agent ID, timestamp, and event data
+agentId:
+  type: Text
+  description: Optional agent identifier
+id:
+  type: Integer
+  description: Optional event ID
+timestamp:
+  type: Integer
+  description: Optional timestamp for the event
+event:
+  description: Optional event node reference

--- a/MyOSDevV0.7/MyOSTimeline.blue
+++ b/MyOSDevV0.7/MyOSTimeline.blue
@@ -1,0 +1,6 @@
+name: MyOS Timeline
+type: Timeline
+description: A managed timeline implementation providing convenient email-based authentication and extensive features. MyOS timelines are straightforward to set up and use, offering a balance of convenience and security through hash-chained, authenticated event sequences.
+accountId:
+  type: Integer
+  description: Numeric identifier for the MyOS account associated with this timeline

--- a/MyOSDevV0.7/MyOSTimelineChannel.blue
+++ b/MyOSDevV0.7/MyOSTimelineChannel.blue
@@ -1,0 +1,9 @@
+name: MyOS Timeline Channel
+type: Timeline Channel
+description: MyOS-specific Timeline Channel
+accountId:
+  type: Text
+  description: Account identifier for the MyOS timeline
+email:
+  type: Text
+  description: Email address associated with the MyOS timeline

--- a/MyOSDevV0.7/MyOSTimelineEntry.blue
+++ b/MyOSDevV0.7/MyOSTimelineEntry.blue
@@ -1,0 +1,8 @@
+name: MyOS Timeline Entry
+type: Timeline Entry
+description: MyOS-specific timeline entry with account and email information
+timeline:
+  type: MyOS Timeline
+timestamp:
+  type: Integer
+  description: Timestamp of the MyOS timeline entry

--- a/MyOSDevV0.7/_extends.txt
+++ b/MyOSDevV0.7/_extends.txt
@@ -1,0 +1,1 @@
+CoreDevV0.4


### PR DESCRIPTION
ADDED
- MyOSDevV0.7 
- Document Session Bootstrap in MyOSDevV0.7 

BREAKING CHANGES
- unified `account` to `accountId` in MyOSDevV0.7 
- removed redundant fields in MyOSTimelineEntry

https://github.com/bluecontract/blue-repository-js/pull/55/files