### PR TITLE
feat(myos): add Agent marker, MyOS Package type, and install prompt e…

### DIFF
--- a/MyOSDevV0.14/Agent.blue
+++ b/MyOSDevV0.14/Agent.blue
@@ -1,0 +1,2 @@
+name: Agent
+description: Marker type for a specialized Blue document that MyOS treats as an Agent, enabling richer UI and behaviors while remaining a standard Blue document.

--- a/MyOSDevV0.14/InformUserToInstallMyOSPackage.blue
+++ b/MyOSDevV0.14/InformUserToInstallMyOSPackage.blue
@@ -1,0 +1,11 @@
+name: Inform User To Install MyOS Package
+description: Notifies the user that a MyOS Package is ready to install.
+title:
+  type: Text
+  description: Short, user-facing headline (e.g., "Install Agent Package")
+message:
+  type: Text
+  description: Context for the user (e.g., who suggested it, what it does)
+package:
+  type: MyOS Package
+  description: The complete package to be bootstrapped

--- a/MyOSDevV0.14/MyOSPackage.blue
+++ b/MyOSDevV0.14/MyOSPackage.blue
@@ -1,0 +1,36 @@
+name: MyOS Package
+type: Agent
+description: >
+  A distributable blueprint for a new Agent session, which can include
+  pre-configured automations that start on installation.
+document:
+  description: The full initial state of the Agent to be created. Root type MUST specialize 'Agent'.
+agentStoreDescription:
+  type: Text
+  description: Human-readable description for stores/directories
+channelBindings:
+  type: Dictionary
+  keyType: Text
+  valueType: Channel
+  description: Maps channel names to participant identifiers
+installerChannel:
+  type: Text
+  description: Channel name in 'document' to bind to the installing user/account
+initialMessages:
+  description: Optional per-participant invitation messages (installer's message is public)
+  defaultMessage:
+    type: Text
+    description: Default invitation message sent to all participants
+  perChannel:
+    type: Dictionary
+    keyType: Text
+    valueType: Text
+    description: Per-channel custom invitation messages
+capabilities:
+  type: Dictionary
+  keyType: Text
+  valueType: Boolean
+  description: Optional MyOS Admin capability contracts to attach (participantsOrchestration, sessionInteraction, workerAgency)
+automationTemplate:
+  type: Anchor Automation Template
+  description: Optional automation template to start post-creation


### PR DESCRIPTION
…vent

- Add MyOSDevV0.14/Agent.blue: generic Agent marker type for MyOS-specific behaviors while remaining a standard Blue document.
- Add MyOSDevV0.14/MyOSPackage.blue: distributable blueprint for creating a new Agent session; includes document, agentStoreDescription, channelBindings,  installerChannel, initialMessages, capabilities, automationTemplate.
- Add MyOSDevV0.14/InformUserToInstallMyOSPackage.blue: minimal pending-action event to prompt the user to install a provided MyOS Package (title, message, package).

Rationale: Reuses the existing pending-actions pattern with a dedicated event for package installation, enabling third-party apps (e.g., ChatGPT) to propose packages and the UI to guide users through installation.