### PR TITLE
Add deterministic JavaScript module contracts

### DIFF
--- a/Conversation/JavaScriptCode.v2.dev.blue
+++ b/Conversation/JavaScriptCode.v2.dev.blue
@@ -1,0 +1,160 @@
+name: JavaScript Code v2
+type: Conversation/Sequential Workflow Step
+description: >
+  Conversation workflow step that executes provided JavaScript source as part of
+  a sequential workflow.
+
+  The step supports two source shapes while keeping one workflow step type:
+
+  - Script mode executes `code` with the existing JavaScript step semantics.
+    This is the default for existing documents.
+  - Module mode treats `code` as the entry ES module and builds a deterministic
+    module graph from the entry source, inline `modules`, and reusable
+    `libraries`. The processor must convert the graph to a canonical, hashed
+    QuickJS ModulePack before evaluation. Runtime execution must not resolve
+    modules from the filesystem, network, npm registry, or any other ambient
+    source.
+
+  Mode selection:
+
+  - `mode: script` always uses script semantics.
+  - `mode: module` always uses module semantics.
+  - `mode: auto` or omitted uses script semantics unless `entryExport`,
+    `modules`, or `libraries` is present; then it uses module semantics.
+
+  Deterministic module loading rules:
+
+  - The entry module has the implicit stable specifier `./entry.js`.
+  - `modules` is a dictionary from module specifier to JavaScript source.
+  - Local module specifiers must start with `./`, must not contain `..` path
+    segments, must not contain backslashes, and must be unique after
+    normalization.
+  - Static imports must resolve only to the entry module, inline modules,
+    reusable `Conversation/JavaScript Library` modules, or verified locked
+    artifacts. Missing imports are document-processing errors, not late runtime
+    lookups.
+  - Dynamic `import()`, CommonJS `require()`, Node built-ins, filesystem access,
+    network access, and package-manager resolution are not part of the runtime
+    module loader.
+  - Source text is normalized for hashing by converting CRLF/CR line endings to
+    LF and otherwise preserving bytes.
+  - The module graph must be canonicalized and graph-hashed before evaluation;
+    the runtime verifies the graph hash again before executing the pack.
+
+  - Deterministic JavaScript runtime (QuickJS in Wasm):
+      - Only deterministic APIs are available. Date, Math.random, eval/Function,
+        Promise/async, RegExp, Proxy, ArrayBuffer/typed arrays, WebAssembly,
+        console, JSON.parse/stringify, and Array.prototype.sort are disabled.
+      - Values passed into and returned from the VM must be DV-compatible
+        (null, boolean, number, string, array, object with string keys).
+  - Gas accounting (when and what is charged):
+      - JavaScript execution is metered by the QuickJS VM. The VM reports wasm
+        fuel used; the processor converts it to host gas with:
+          hostGas = ceil(wasmFuel / 1700)
+        (calibration factor currently 1700 fuel per host gas unit).
+      - Document snapshot reads (via document(<pointer>) inside the code):
+        8 + depth(pointer) + ceil(snapshotBytes/100) per call, where:
+          - depth("/") = 0, depth("/a/b") = 2 (number of path segments),
+          - snapshotBytes is the canonical JSON size of the retrieved snapshot.
+      - Event emissions (if the returned result contains events: [...]):
+        20 + ceil(eventBytes/100) per emitted event, where eventBytes is the
+        canonical JSON size of that event. (Delivery/handling of those events may incur
+        additional charges elsewhere, outside this step.)
+  - JavaScript bindings available to the code:
+      - `event`: triggering event rendered via the `'simple'` JSON strategy (plain
+        values/arrays, no metadata).
+      - `eventCanonical`: triggering event rendered via the `'official'` strategy.
+      - `currentContract`: the current handler contract rendered via the `'simple'`
+        JSON strategy.
+      - `currentContractCanonical`: current handler contract rendered via the
+        `'official'` strategy.
+      - `document(pointer?)`: document snapshot (absolute path or scope-relative) rendered
+        with the `'simple'` strategy; defaults to `/` when omitted.
+      - `document.canonical(pointer?)`: snapshot rendered using the `'official'`
+        strategy for canonical metadata.
+      - `steps`: results of previously executed steps.
+      - `canon.unwrap(canonical, deep=true)`: converts canonical JSON back to plain values.
+      - `canon.at(canonical, pointer)`: JSON Pointer navigation helper for canonical
+        JSON objects.
+
+  Examples:
+
+  Script mode:
+
+      - type: Conversation/JavaScript Code v2
+        code: |
+          return document('/counter') + 1;
+
+  Inline module mode:
+
+      - type: Conversation/JavaScript Code v2
+        mode: module
+        code: |
+          import { inc } from './math.js';
+          export default inc(document('/counter'));
+        modules:
+          './math.js': |
+            export function inc(value) {
+              return value + 1;
+            }
+
+  Reusable library mode:
+
+      contracts:
+        mathLibrary:
+          type: Conversation/JavaScript Library
+          modules:
+            './math.js': |
+              export function inc(value) {
+                return value + 1;
+              }
+
+        onInit:
+          type: Conversation/Sequential Workflow
+          steps:
+            - type: Conversation/JavaScript Code v2
+              mode: module
+              libraries:
+                - /contracts/mathLibrary
+              code: |
+                import { inc } from './math.js';
+                export default inc(1);
+
+code:
+  type: Text
+  description: >
+    JavaScript source to execute for this step. In script mode this is the
+    complete script body. In module mode this is the entry ES module and has the
+    implicit module specifier `./entry.js`.
+mode:
+  type: Text
+  description: >
+    Optional execution mode. Supported values are `script`, `module`, and
+    `auto`. Missing mode behaves as `auto`: existing plain `code` steps run as
+    scripts, while steps with `entryExport`, `modules`, or `libraries` run as
+    deterministic ES modules.
+entryExport:
+  type: Text
+  description: >
+    Optional module export to read in module mode. Defaults to `default`. This
+    field is not applicable in script mode and should be rejected when
+    `mode: script` is selected explicitly.
+modules:
+  type: Dictionary
+  keyType: Text
+  valueType: Text
+  description: >
+    Optional inline ES modules for module mode. Keys are canonical module
+    specifiers, and values are JavaScript source text. Local specifiers must use
+    `./` paths, must not contain `..` segments or backslashes, and must be unique
+    after normalization. The processor builds the static import closure from
+    `./entry.js` and rejects missing or ambiguous imports before evaluation.
+libraries:
+  type: List
+  itemType: Text
+  description: >
+    Optional ordered list of document pointers to reusable
+    `Conversation/JavaScript Library` contracts. Library modules and locked
+    artifacts are merged with the entry and inline modules deterministically.
+    Duplicate normalized specifiers across libraries, inline modules, and the
+    entry module are document-processing errors.

--- a/Conversation/JavaScriptLibrary.dev.blue
+++ b/Conversation/JavaScriptLibrary.dev.blue
@@ -1,0 +1,108 @@
+name: JavaScript Library
+type: Core/Contract
+description: >
+  Reusable JavaScript module set for `Conversation/JavaScript Code` module mode.
+  A library lets authors share many modules through one Blue contract instead of
+  creating one Blue document per JavaScript file.
+
+  Libraries are source or artifact providers only; they are not workflow steps
+  and are not executed directly. A `Conversation/JavaScript Code` step consumes a
+  library through its `libraries` field, merges the provided modules or verified
+  artifacts into the step's module graph, and then evaluates a single canonical,
+  graph-hashed QuickJS ModulePack.
+
+  Determinism requirements:
+
+  - `modules` keys are canonical module specifiers and values are JavaScript
+    source text.
+  - Local module specifiers must start with `./`, must not contain `..` path
+    segments, must not contain backslashes, and must be unique after
+    normalization across every source provider used by a step.
+  - Source text is normalized for hashing by converting CRLF/CR line endings to
+    LF and otherwise preserving bytes.
+  - External packages are represented only by locked artifacts. Document
+    processing and runtime evaluation must not fetch from npm, read the
+    filesystem, or perform ambient package resolution.
+  - If both `modules` and `artifact` are present, the processor must verify that
+    their hashes and declared package metadata agree before using the library.
+
+  Local source library example:
+
+      contracts:
+        commonJavaScript:
+          type: Conversation/JavaScript Library
+          modules:
+            './math.js': |
+              export function add(left, right) {
+                return left + right;
+              }
+            './format.js': |
+              export function format(value) {
+                return 'value=' + value;
+              }
+
+  A workflow step can then import from the shared module set:
+
+      - type: Conversation/JavaScript Code
+        mode: module
+        libraries:
+          - /contracts/commonJavaScript
+        code: |
+          import { add } from './math.js';
+          import { format } from './format.js';
+          export default format(add(1, 2));
+
+modules:
+  type: Dictionary
+  keyType: Text
+  valueType: Text
+  description: >
+    Optional reusable ES module source map. Keys are canonical module specifiers;
+    values are JavaScript source text. A consuming step computes the static
+    import closure from its own `./entry.js`, so libraries may contain multiple
+    modules while only the reachable subset is executed.
+package:
+  description: >
+    Optional package identity for a locked external library artifact. This is
+    descriptive and verifiable metadata only; it must not trigger network,
+    registry, or filesystem lookup during document processing.
+  registry:
+    type: Text
+    description: Package registry identifier, for example `npm`.
+  packageName:
+    type: Text
+    description: Package name or import name, for example `chess.js`.
+  version:
+    type: Text
+    description: Exact package version used to build the artifact.
+  sourceIntegritySha256:
+    type: Text
+    description: SHA-256 integrity of the package source input used by the artifact builder.
+artifact:
+  description: >
+    Optional locked deterministic artifact for external or generated libraries.
+    The artifact must contain enough data for the processor to verify the module
+    pack without fetching or resolving dependencies at runtime. The exact module
+    pack shape is owned by the deterministic JavaScript runtime package, but the
+    fields below are the repository-level verification envelope.
+  builderVersion:
+    type: Text
+    description: Deterministic artifact builder version.
+  dependencyIntegrity:
+    type: Text
+    description: SHA-256 integrity of the resolved dependency set used by the artifact builder.
+  graphHash:
+    type: Text
+    description: Graph hash of the contained deterministic ModulePack.
+  modulePack:
+    description: The serialized deterministic QuickJS ModulePack to verify and merge.
+moduleAliases:
+  type: Dictionary
+  keyType: Text
+  valueType: Text
+  description: >
+    Optional deterministic import alias map. Keys are import specifiers accepted
+    by consuming code; values are canonical module specifiers provided by
+    `modules` or by the locked `artifact`. Aliases are useful for package-style
+    imports such as `chess.js` when the artifact stores canonical internal
+    module paths.


### PR DESCRIPTION
Introduce JavaScript Code v2 as a workflow step that supports both legacy script execution and deterministic ES module execution. Define module graph loading, normalization, hashing, runtime restrictions, gas accounting, bindings, and examples.

Add JavaScript Library as a reusable contract for shared module source maps and locked artifacts, including deterministic package metadata, artifact verification fields, and import alias support.